### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# elm-package generated files
+elm-stuff
+# elm-repl generated files
+repl-temp-*


### PR DESCRIPTION
## Why?

Added GitHub's default Elm .gitignore file, which removes `elm-stuff` from version control.